### PR TITLE
fix: BoardController의 CustomUserDetail 추가

### DIFF
--- a/src/main/java/hackathon/bigone/sunsak/accounts/mypage/controller/MypageController.java
+++ b/src/main/java/hackathon/bigone/sunsak/accounts/mypage/controller/MypageController.java
@@ -3,8 +3,11 @@ package hackathon.bigone.sunsak.accounts.mypage.controller;
 import hackathon.bigone.sunsak.accounts.mypage.dto.NoticeDto;
 import hackathon.bigone.sunsak.accounts.mypage.dto.PasswordChangeDto;
 import hackathon.bigone.sunsak.accounts.mypage.service.MypageService;
+import hackathon.bigone.sunsak.accounts.user.entity.SiteUser;
 import hackathon.bigone.sunsak.global.security.jwt.CustomUserDetail;
 import hackathon.bigone.sunsak.global.validate.accounts.SignupValidator;
+import hackathon.bigone.sunsak.recipe.board.dto.BoardDto;
+import hackathon.bigone.sunsak.recipe.board.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +24,7 @@ import java.util.Map;
 public class MypageController {
     private final SignupValidator signupValidator;
     private final MypageService mypageService;
+    private final BoardService boardService; //레시피
 
     //마이페이지 조회
     @GetMapping("")
@@ -99,5 +103,17 @@ public class MypageController {
         return mypageService.getNoticeById(noticeId)
                 .map(ResponseEntity::ok)                // 200 + DTO(JSON)
                 .orElseGet(() -> ResponseEntity.notFound().build()); // 404
+    }
+
+    //스크랩
+    @GetMapping("/scrap")
+    public ResponseEntity<List<BoardDto>> getMyScrapBoards(@AuthenticationPrincipal CustomUserDetail userDetail){
+        if(userDetail == null){
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        }
+        SiteUser currentUser = userDetail.getUser();
+
+        List<BoardDto> scrapBoards = boardService.getScrapBoardsByUser(currentUser);
+        return ResponseEntity.ok(scrapBoards);
     }
 }

--- a/src/main/java/hackathon/bigone/sunsak/recipe/board/controller/BoardController.java
+++ b/src/main/java/hackathon/bigone/sunsak/recipe/board/controller/BoardController.java
@@ -1,21 +1,15 @@
 package hackathon.bigone.sunsak.recipe.board.controller;
 
-import hackathon.bigone.sunsak.accounts.user.repository.UserRepository;
 import hackathon.bigone.sunsak.accounts.user.entity.SiteUser;
+import hackathon.bigone.sunsak.accounts.user.repository.UserRepository;
+import hackathon.bigone.sunsak.global.security.jwt.CustomUserDetail;
 import hackathon.bigone.sunsak.recipe.board.dto.BoardDto;
 import hackathon.bigone.sunsak.recipe.board.entity.Board;
 import hackathon.bigone.sunsak.recipe.board.service.BoardService;
-import jakarta.persistence.EntityNotFoundException;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -40,64 +34,64 @@ public class BoardController {
         BoardDto board = boardService.findBoardById(postId);
         return ResponseEntity.ok(board);
     }
+
+    //UserDetial을 CustomUserDetail로 변경
+    //CustomUserDetail 안에 SiteUser 엔티티가 직접 있어서 DB 재조회 불필요
     @PostMapping
     public ResponseEntity<String> createBoard(@RequestBody BoardDto boardDto,
-                                               @AuthenticationPrincipal UserDetails userDetails) {
-        if(userDetails == null){
+                                              @AuthenticationPrincipal CustomUserDetail userDetail) {
+        if(userDetail == null){
             return new ResponseEntity<>("로그인이 필요합니다.", HttpStatus.UNAUTHORIZED);
         }
-        SiteUser author = userRepository.findByUsername(userDetails.getUsername())
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+        SiteUser author = userDetail.getUser();
         boardService.create(boardDto, author);
-        return new ResponseEntity<>("게시글이 성공적으로 생성되었습니다.", HttpStatus.CREATED);}
+
+        return new ResponseEntity<>("게시글이 성공적으로 생성되었습니다.", HttpStatus.CREATED);
+    }
 
     @PatchMapping("/boards/{postId}")
     public ResponseEntity<Board> updateBoard(@PathVariable Long postId, @RequestBody BoardDto boardDto,
-                                             @AuthenticationPrincipal UserDetails userDetails){
-        if (userDetails == null) {
+                                             @AuthenticationPrincipal CustomUserDetail userDetail){
+        if (userDetail == null) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
-        SiteUser currentUser = userRepository.findByUsername(userDetails.getUsername())
-                .orElseThrow(() -> new EntityNotFoundException(("사용자를 찾을 수 없습니다.")));
+        SiteUser currentUser = userDetail.getUser();
         Board updatedBoard = boardService.updateBoard(postId, boardDto, currentUser);
 
         return ResponseEntity.ok(updatedBoard);
-        }
+    }
 
     //좋아요
-    @PostMapping("{postId}/like")
-    public ResponseEntity<String> toggleLike(@PathVariable Long postId, @AuthenticationPrincipal UserDetails userDetails) {
+    @PostMapping("/{postId}/like") //경로 '/' 없어서 추가
+    public ResponseEntity<String> toggleLike(
+            @PathVariable Long postId, @AuthenticationPrincipal CustomUserDetail userDetail
+    ) {
+        if (userDetail == null) {
+            return new ResponseEntity<>("로그인이 필요합니다.", HttpStatus.UNAUTHORIZED);
+        }
+
+        SiteUser currentUser = userDetail.getUser();
+        boardService.toggleLike(postId, currentUser); //서비스 호출
+
         return ResponseEntity.ok("좋아요 상태가 변경되었습니다.");
     }
 
     @PostMapping("/{postId}/scrap")
-    public ResponseEntity<String> toggleScrap(@PathVariable Long postId, @AuthenticationPrincipal UserDetails userDetails){
+    public ResponseEntity<String> toggleScrap(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetail userDetail
+    ){
+        if (userDetail == null) {
+            return new ResponseEntity<>("로그인이 필요합니다.", HttpStatus.UNAUTHORIZED);
+        }
+
+        SiteUser currentUser = userDetail.getUser();
+        boardService.toggleScrap(postId, currentUser); //서비스 호출
+
         return ResponseEntity.ok("스크랩 상태가 변경되었습니다.");
     }
 
-    @GetMapping("/mypage/likes")
-    public ResponseEntity<List<BoardDto>> getMyLikedBoards(@AuthenticationPrincipal UserDetails userDetails){
-        if(userDetails == null){
-            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
-        }
-        SiteUser currentUser = userRepository.findByUsername(userDetails.getUsername())
-                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
-        List<BoardDto> likedBoards = boardService.getLikedBoardsByUser(currentUser);
-        return ResponseEntity.ok(likedBoards);
-    }
-
-    @GetMapping("/mypage/scrap")
-    public ResponseEntity<List<BoardDto>> getMyScrapBoards(@AuthenticationPrincipal UserDetails userDetails){
-        if(userDetails == null){
-            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
-        }
-        SiteUser currentUser = userRepository.findByUsername(userDetails.getUsername())
-                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
-
-        List<BoardDto> scrapBoards = boardService.getScrapBoardsByUser(currentUser);
-        return ResponseEntity.ok(scrapBoards);
-    }
-    }
+}
 
 


### PR DESCRIPTION
UserDetails를 상속한 CustomUserDetail을 사용해서 username에서 DB 조회 과정을 생략할 수 있다.
-> 코드가 간단해짐!